### PR TITLE
Add the Capbility to have MultiARCH containers to the repository.

### DIFF
--- a/.github/workflows/multi-arch-docker-build-and-push.yml
+++ b/.github/workflows/multi-arch-docker-build-and-push.yml
@@ -1,0 +1,34 @@
+name: multi-arch-docker-build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  multi-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            lhaig/hashibo:latest

--- a/.github/workflows/multi-arch-docker-build-and-push.yml
+++ b/.github/workflows/multi-arch-docker-build-and-push.yml
@@ -31,4 +31,4 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
-            lhaig/hashibo:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/hashibo:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+COPY reveal /usr/share/nginx/html/
+RUN echo daemon off\; >> /etc/nginx/nginx.conf
+RUN chown -R nginx /usr/share/nginx/html/
+CMD ["nginx"]
+EXPOSE 80
+


### PR DESCRIPTION
You will need to add some Dockerhub Secrets to enable this workflow.

- DOCKERHUB_USERNAME
- DOCKERHUB_TOKEN

The workflow is triggered on a release and pushes to the latest tag for a container.

